### PR TITLE
Strip trailing spaces from headlines

### DIFF
--- a/cyberprefixer.py
+++ b/cyberprefixer.py
@@ -82,7 +82,7 @@ def get():
                 continue
 
 def process(headline):
-    headline = hparser.unescape(headline)
+    headline = hparser.unescape(headline).strip()
     tagged = tagger(headline)
     for i, word in enumerate(tagged):
         # Avoid having two "cybers" in a row


### PR DESCRIPTION
- if the feed included spaces in headlines, this would cause attempts to submit duplicate statuses
- twitter strips leading and traling spaces, so the tweets retrieved wouldn't match those generated
