### PR TITLE
Tact in offensive makes reuse easier

### DIFF
--- a/cyberprefixer.py
+++ b/cyberprefixer.py
@@ -20,10 +20,9 @@
 
 import HTMLParser
 import os
-import re
 import tweepy
 import urllib2
-from offensive import offensive
+from offensive import tact
 from secrets import *
 from bs4 import BeautifulSoup
 from topia.termextract import tag
@@ -112,14 +111,6 @@ def tweet(headline):
     # Post tweet
     api.update_status(headline)
     return True
-
-
-def tact(headline):
-    # Avoid producing particularly tactless tweets
-    if re.search(offensive, headline) is None:
-        return True
-    else:
-        return False
 
 
 def count_caps(headline):

--- a/offensive.py
+++ b/offensive.py
@@ -12,3 +12,11 @@ offensive = re.compile(
     r"rampage|beat(ings?|en)|terminal(ly)?|abduct(s|ed|ion)?s?|missing|behead(s|ed|ings?)?|"
     r"homicid(e|es|al)|burn(s|ed|ing)? alive|decapitated?s?)\W?\b",
     flags=re.IGNORECASE)
+
+
+def tact(headline):
+    # Avoid producing particularly tactless tweets
+    if re.search(offensive, headline) is None:
+        return True
+    else:
+        return False


### PR DESCRIPTION
The big ol' `offensive` regex looks like it would be useful for other projects using Google News headlines. 

It makes sense to use it along with `tact()`, so how about popping them in the same file?

See http://motherboard.vice.com/en_ca/read/whos-responsible-for-what-bots-say-online for more on this problem, and https://github.com/dariusk/wordfilter and https://github.com/sjml/bot-innocence which approach the same problem in different ways.