### PR TITLE
Update offensive

### DIFF
--- a/offensive.py
+++ b/offensive.py
@@ -10,7 +10,7 @@ offensive = re.compile(
     r"al[- ]?Qaeda|blasts?|violen(t|ce)|lethal|cancer(ous)?|stab(bed|bing|ber)?s?|casualt(y|ies)|"
     r"sla(y|ying|yer|in)|drown(s|ing|ed|ings)?|bod(y|ies)|kidnap(s|ped|per|pers|ping|pings)?|"
     r"rampage|beat(ings?|en)|terminal(ly)?|abduct(s|ed|ion)?s?|missing|behead(s|ed|ings?)?|"
-    r"homicid(e|es|al)|burn(s|ed|ing)? alive|decapitated?s?)\W?\b",
+    r"homicid(e|es|al)|burn(s|ed|ing)? alive|decapitated?s?|jihadi?s?t?)\W?\b",
     flags=re.IGNORECASE)
 
 


### PR DESCRIPTION
Hopefully this does what I want and my regex-fu is not entirely weak sauce. It should be excluding:

* Jihad
* Jihadi
* Jihadis
* Jihadist

To avoid headlines which, even without assaults or rampages, can end up...awkward.